### PR TITLE
36 event description does not maintain newlines

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1050,7 +1050,7 @@ const EMAIL_TEMPLATES: [(&str, &str); 3] = [
 
         <p>It starts at {{ time_begin }} and runs until {{ time_end }}.</p>
 
-        <p>{{ description }}</p>
+        <p>{{ description | linebreaksbr }}</p>
 
         <p>I've created a new website for these events where you can RSVP and see details about the event. In the future, you will also be able to let me know which times you can attend, reserve seats, suggest and vote for games, as well as a live dashboard for during the event itself. It's a constant work in progress, so please let me know if you have any issues or feedback.</p>
 

--- a/frontend/src/components/Event.tsx
+++ b/frontend/src/components/Event.tsx
@@ -73,7 +73,11 @@ const Event = () => {
                 </Paper>
               </Grid>
               <Grid item xs={12}>
-                <Typography variant="body1" gutterBottom>
+                <Typography
+                  variant="body1"
+                  gutterBottom
+                  sx={{ whiteSpace: "pre-wrap" }}
+                >
                   {event.description}
                 </Typography>
               </Grid>

--- a/frontend/src/components/EventManagement.tsx
+++ b/frontend/src/components/EventManagement.tsx
@@ -80,7 +80,11 @@ const EventManagement = () => {
               >
                 {event.title}
               </Typography>
-              <Typography variant="body1" gutterBottom>
+              <Typography
+                variant="body1"
+                gutterBottom
+                sx={{ whiteSpace: "pre-wrap" }}
+              >
                 {event.description}
               </Typography>
               <Stack direction="row" spacing={2}>

--- a/frontend/src/components/EventSelection.tsx
+++ b/frontend/src/components/EventSelection.tsx
@@ -48,7 +48,11 @@ const Event = () => {
                     .sort((a, b) => a.timeBegin.unix() - b.timeBegin.unix())[0]
                     ?.timeEnd.calendar()}
                 </Typography>
-                <Typography variant="body2" color="text.secondary">
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ whiteSpace: "pre-wrap" }}
+                >
                   {
                     events.sort(
                       (a, b) => a.timeBegin.unix() - b.timeBegin.unix(),

--- a/frontend/src/components/EventTable.tsx
+++ b/frontend/src/components/EventTable.tsx
@@ -125,7 +125,11 @@ const GridCellExpand = memo(function GridCellExpand(
             elevation={1}
             style={{ minHeight: wrapper.current!.offsetHeight - 3 }}
           >
-            <Typography variant="body2" style={{ padding: 8 }}>
+            <Typography
+              variant="body2"
+              style={{ padding: 8 }}
+              sx={{ whiteSpace: "pre-wrap" }}
+            >
               {value}
             </Typography>
           </Paper>


### PR DESCRIPTION
In emails:
![image](https://user-images.githubusercontent.com/126488/197354749-478c2758-9ac5-4396-b7aa-c2142253393b.png)

And on the website:
![image](https://user-images.githubusercontent.com/126488/197354864-4c4bd276-733e-4717-9d4c-50f1053ff205.png)

