### PR TITLE
Disabling rebase-strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,27 +28,32 @@ updates:
       interval: "daily"
       time: "21:00"
     open-pull-requests-limit: 10
+    rebase-strategy: "disabled"
   - package-ecosystem: "docker"
     directory: "/frontend/"
     schedule:
       interval: "daily"
       time: "21:00"
     open-pull-requests-limit: 10
+    rebase-strategy: "disabled"
   - package-ecosystem: "cargo"
     directory: "/api/"
     schedule:
       interval: "daily"
       time: "21:00"
     open-pull-requests-limit: 10
+    rebase-strategy: "disabled"
   - package-ecosystem: "docker"
     directory: "/api/"
     schedule:
       interval: "daily"
       time: "21:00"
     open-pull-requests-limit: 10
+    rebase-strategy: "disabled"
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
       interval: "daily"
       time: "21:00"
     open-pull-requests-limit: 10
+    rebase-strategy: "disabled"


### PR DESCRIPTION
This avoids bors being cancelled when mass-merging dependabot PRs.