### PR TITLE
API: Fix verify email link

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -144,7 +144,7 @@ const EMAIL_TEMPLATES: [(&str, &str); 3] = [
 
         <p>Please confirm your email by visiting the following link in the next 30 minutes: <a href="https://calandar.org/verify_email?token={{ token }}">Validate Email</a></p>
 
-        <p>Alternatively, go to <a href=\"https://calandar.org/verify_email\">https://calandar.org/verify_email</a> and enter the following token:</p>
+        <p>Alternatively, go to <a href="https://calandar.org/verify_email">https://calandar.org/verify_email</a> and enter the following token:</p>
 
         <code>{{ token }}</code>
 


### PR DESCRIPTION
Removes escape backslashes from email link, so that when users click on the link, it opens in their web browser. Previously, the backslashes were rendered into the HTML and browsers would attempt to load `http:///"https://calandar.org/verify_email"`.