### PR TITLE
Fixed shuttle deploy secrets

### DIFF
--- a/.github/workflows/shuttle-deploy.yml
+++ b/.github/workflows/shuttle-deploy.yml
@@ -16,5 +16,5 @@ jobs:
           working-directory: api
           secrets: |
             PASETO_SECRET_KEY = '${{ secrets.PASETO_SECRET_KEY }}'
-            SENDGRID_API_KEY = '${{ secrets.SENDGRID_API_KEY }}'
+            RESEND_API_KEY = '${{ secrets.RESEND_API_KEY }}'
             STEAM_API_KEY = '${{ secrets.STEAM_API_KEY }}'


### PR DESCRIPTION
This PR updates the email service configuration in the deployment workflow by replacing SendGrid with Resend as the email provider.

- Updates the GitHub Actions workflow to use the correct API key secret for the new email service